### PR TITLE
#32 画面幅が狭い場合、トグルボタンを下に表示するよう変更

### DIFF
--- a/CREC_Web/Views/Home/Index.cshtml
+++ b/CREC_Web/Views/Home/Index.cshtml
@@ -84,7 +84,7 @@
             <div class="col-12 col-md-6">
                 <span id="resultsText"></span>
             </div>
-            <div class="col-12 col-md-6 d-flex justify-content-end align-items-center">
+            <div class="col-12 col-md-6 d-flex justify-content-end">
                 <div class="btn-group view-toggle-buttons" role="group" aria-label="View mode toggle">
                     <button type="button" class="btn btn-outline-primary" id="gridViewBtn" title="Grid View / グリッド表示">
                         <i class="bi bi-grid-3x3-gap"></i>


### PR DESCRIPTION
幅が広い時：左寄せで検索結果、右寄せでトグルボタンを表示
幅が狭い時：左寄せで検索結果、一段下げて右寄せでトグルボタンを表示