### PR TITLE
Port設定を手動でできるよう修正

### DIFF
--- a/CREC_Web/Program.cs
+++ b/CREC_Web/Program.cs
@@ -256,6 +256,14 @@ static ProjectSettings? ParseCrecFile(string crecFilePath)
 // ポートが利用可能か確認する関数
 static bool IsPortAvailable(int port)
 {
+    // ポートが設定可能範囲な数値内か確認
+    if (port < 1 || port > 65535)
+    {
+        Console.WriteLine($"Port {port} is out of valid range (1-65535).");
+        return false;
+    }
+
+    // ポートが使用中か確認
     try
     {
         using var listener = new System.Net.Sockets.TcpListener(System.Net.IPAddress.Any, port);


### PR DESCRIPTION
以下の仕様とする
・入力値をHTTPSのポート、入力値＋１をHTTPのポートとする
・入力値が不適切もしくは無い場合は、デフォルト値の5000とする