### PR TITLE
画像関連のAPI呼び出し名の変更

### DIFF
--- a/CREC_Web/Controllers/FileController.cs
+++ b/CREC_Web/Controllers/FileController.cs
@@ -35,8 +35,8 @@ namespace CREC_Web.Controllers
         /// <param name="collectionId">コレクションID</param>
         /// <param name="fileName">画像ファイル名</param>
         /// <returns>画像ファイル</returns>
-        // 呼び出し例: /api/File/{collectionId}/{fileName}
-        [HttpGet("{collectionId}/{fileName}")]
+        // 呼び出し例: /api/File/{collectionId}/picture/{fileName}
+        [HttpGet("{collectionId}/picture/{fileName}")]
         public IActionResult GetFile(string collectionId, string fileName)
         {
             try
@@ -125,8 +125,8 @@ namespace CREC_Web.Controllers
         /// <param name="collectionId">コレクションID</param>
         /// <param name="fileName">ファイル名</param>
         /// <returns>ファイル（配信用）</returns>
-        // 呼び出し例: /api/File/data/{collectionId}/{pictureFileName}
-        [HttpGet("data/{collectionId}/{fileName}")]
+        // 呼び出し例: /api/File/{collectionId}/data/{fileName}
+        [HttpGet("{collectionId}/data/{fileName}")]
         public IActionResult GetDataFile(string collectionId, string fileName)
         {
             try

--- a/CREC_Web/Views/Collection/Index.cshtml
+++ b/CREC_Web/Views/Collection/Index.cshtml
@@ -519,7 +519,7 @@
             const carouselHtml = images.length > 0
                 ? `
                     <div class="image-carousel">
-                        <img id="carouselImage" src="/api/File/${encodeURIComponent(collection.indexData.systemData.id)}/${encodeURIComponent(images[currentImageIndex])}" 
+                        <img id="carouselImage" src="/api/File/${encodeURIComponent(collection.indexData.systemData.id)}/picture/${encodeURIComponent(images[currentImageIndex])}" 
                                 class="detail-image" 
                                 alt="${escapeHtml(images[currentImageIndex])}"
                                 onerror="this.onerror=null; this.src='data:image/svg+xml,%3Csvg xmlns=\\'http://www.w3.org/2000/svg\\' width=\\'200\\' height=\\'200\\'%3E%3Crect width=\\'200\\' height=\\'200\\' fill=\\'%23ddd\\'/%3E%3Ctext x=\\'50%25\\' y=\\'50%25\\' dominant-baseline=\\'middle\\' text-anchor=\\'middle\\' font-family=\\'sans-serif\\' font-size=\\'16\\' fill=\\'%23999\\'%3EImage not found%3C/text%3E%3C/svg%3E';">
@@ -591,7 +591,7 @@
                 ? collection.otherFiles.map(file => `
                     <li class="list-group-item d-flex justify-content-between align-items-center">
                         ${escapeHtml(file)}
-                        <a href="/api/File/data/${encodeURIComponent(collection.indexData.systemData.id)}/${encodeURIComponent(file)}"
+                        <a href="/api/File/${encodeURIComponent(collection.indexData.systemData.id)}/data/${encodeURIComponent(file)}"
                             class="btn btn-sm btn-outline-primary" target="_blank" rel="noopener noreferrer">
                             <i class="bi bi-download"></i>
                         </a>
@@ -652,7 +652,7 @@
                             console.error('Collection ID is missing.');
                             return;
                         }
-                        carouselImage.src = `/api/File/${encodeURIComponent(collectionID)}/${encodeURIComponent(images[currentImageIndex])}`;
+                        carouselImage.src = `/api/File/${encodeURIComponent(collectionID)}/picture/${encodeURIComponent(images[currentImageIndex])}`;
                         carouselImage.alt = images[currentImageIndex];
                         imageCounter.textContent = `${currentImageIndex + 1} / ${images.length}`;
                         imageName.textContent = images[currentImageIndex];

--- a/CREC_Web/Views/Home/Index.cshtml
+++ b/CREC_Web/Views/Home/Index.cshtml
@@ -840,7 +840,7 @@
             const imagesHtml = images.length > 0
                 ? `
                     <div class="image-carousel">
-                        <img id="carouselImage" src="/api/File/${encodeURIComponent(collection.indexData.systemData.id)}/${encodeURIComponent(images[0])}"
+                        <img id="carouselImage" src="/api/File/${encodeURIComponent(collection.indexData.systemData.id)}/picture/${encodeURIComponent(images[0])}"
                                 class="detail-image"
                                 alt="${escapeHtml(images[0])}"
                                 onerror="this.onerror=null; this.src='data:image/svg+xml,%3Csvg xmlns=\'http://www.w3.org/2000/svg\' width=\'200\' height=\'200\'%3E%3Crect width=\'200\' height=\'200\' fill=\'%23ddd\'/%3E%3Ctext x=\'50%25\' y=\'50%25\' dominant-baseline=\'middle\' text-anchor=\'middle\' font-family=\'sans-serif\' font-size=\'16\' fill=\'%23999\'%3EImage not found%3C/text%3E%3C/svg%3E';">
@@ -858,7 +858,7 @@
                 ? collection.otherFiles.map(file => `
                     <li class="list-group-item d-flex justify-content-between align-items-center">
                         ${escapeHtml(file)}
-                        <a href="/api/File/data/${encodeURIComponent(collection.indexData.systemData.id)}/${encodeURIComponent(file)}"
+                        <a href="/api/File/${encodeURIComponent(collection.indexData.systemData.id)}/data/${encodeURIComponent(file)}"
                             class="btn btn-sm btn-outline-primary" target="_blank" rel="noopener noreferrer">
                             <i class="bi bi-download"></i>
                         </a>
@@ -993,7 +993,7 @@
                             console.error('Collection ID is missing.');
                             return;
                         }
-                        carouselImage.src = `/api/File/${encodeURIComponent(collectionID)}/${encodeURIComponent(images[currentImageIndex])}`;
+                        carouselImage.src = `/api/File/${encodeURIComponent(collectionID)}/picture/${encodeURIComponent(images[currentImageIndex])}`;
                         carouselImage.alt = images[currentImageIndex];
                         imageCounter.textContent = `${currentImageIndex + 1} / ${images.length}`;
                         imageName.textContent = images[currentImageIndex];


### PR DESCRIPTION
## 概要
#114 での動画ファイル対応に伴い、画像ファイル関連のAPI名が曖昧になったため以下のように変更する

- [x]  [HttpGet("{collectionId}/{fileName}")] ->  [HttpGet("{collectionId}/picture/{fileName}")]
- [x] [HttpGet("data/{collectionId}/{fileName}")] -> [HttpGet("{collectionId}/data/{fileName}")]
- [x] 動作に変化がないことを要件とする。

## 関連Issue
#117 #119 