### PR TITLE
コレクション画面縦長表示時のUI改善: モバイルモードのスクロールバー廃止

### DIFF
--- a/CREC_Web/Views/Collection/Index.cshtml
+++ b/CREC_Web/Views/Collection/Index.cshtml
@@ -269,6 +269,7 @@
             .history-table-separator {
                 display: block;
                 margin: 0 1rem;
+                border: 0;
                 border-top: 2px solid #dee2e6;
             }
         }


### PR DESCRIPTION
## 概要
縦長画面表示において、スクロールバーが各要素ごとに発生し操作性が悪い問題があった。
そのため、在庫操作履歴のような大量のデータが縦に並ぶ要素以外についてはスクロールバーを廃止した。
本変更はCollection画面かつ縦長表示モードに対して行う。

## 関連Issue、PR
#118 
#121 