### PR TITLE
Collection画面の更新を連打すると、プロジェクト設定値でなく言語ファイル記述のデフォルト値が使用される場合がある不具合を修正

### DIFF
--- a/CREC_Web/Views/Collection/Index.cshtml
+++ b/CREC_Web/Views/Collection/Index.cshtml
@@ -1255,6 +1255,8 @@
                 }
             });
 
+            // プロジェクト設定を先に読み込んでからコレクション詳細を読み込む（競合状態の防止）
+            await loadProjectSettings();
             await loadCollectionDetails();
             // URLに ?edit=1 が含まれる場合は編集モーダルを自動で開く（リロード時に再度開かないようURLから edit フラグのみ除去）
             if (new URLSearchParams(window.location.search).get('edit') === '1' && currentCollection) {


### PR DESCRIPTION
## 概要
Collection画面の更新を連打すると、プロジェクト設定値でなく言語ファイル記述のデフォルト値が使用される場合がある
そのためページ読み込み処理時にプロジェクト設定値を明示的に読み込む処理を追加

## 関連Issue、PR
#136 
#138 